### PR TITLE
Added redis and rabbitmq, fixed keystore aliases

### DIFF
--- a/.profile
+++ b/.profile
@@ -17,14 +17,14 @@ else
   JRE_PATH=$HOME/.java/jre
 fi
 
-for SERVICE in postgresql mongodb; do
+for SERVICE in postgresql mongodb rabbitmq redis; do
   LEN="$(echo "${VCAP_SERVICES}" | jq --raw-output ".${SERVICE} | length")"
   for (( i=0; i<${LEN}; i++ )); do
     CA_BASE64="$(echo "${VCAP_SERVICES}" | jq --raw-output ".${SERVICE}[${i}].credentials.ca_base64")"
     if [[ "${CA_BASE64}" != "null" ]]; then
       echoerr "Importing CA certificate for ${SERVICE}[${i}]..."
       echo ${CA_BASE64} | base64 -d > $HOME/tmp/ssl/${SERVICE}${i}.crt
-      ${JRE_PATH}/bin/keytool -keystore ${JRE_PATH}/lib/security/cacerts -storepass changeit -importcert -noprompt -alias mongodb${i} -file $HOME/tmp/ssl/${SERVICE}${i}.crt
+      ${JRE_PATH}/bin/keytool -keystore ${JRE_PATH}/lib/security/cacerts -storepass changeit -importcert -noprompt -alias ${SERVICE}${i} -file $HOME/tmp/ssl/${SERVICE}${i}.crt
       echoerr "Import finished successfully"
     fi
   done


### PR DESCRIPTION
metering has both postgres and rabbitmq, failed due to alias already used in keystore